### PR TITLE
Reimplement annotation literals without private APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,11 @@
       <artifactId>guice</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.12.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
       <version>1.17</version>

--- a/src/test/java/com/cloudbees/sdk/extensibility/AnnotationLiteralTest.java
+++ b/src/test/java/com/cloudbees/sdk/extensibility/AnnotationLiteralTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023, CloudBees Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.cloudbees.sdk.extensibility;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import javax.inject.Named;
+import org.junit.Test;
+
+/**
+ * @author Basil Crow
+ */
+public class AnnotationLiteralTest {
+    @Test
+    public void smokes() {
+        Named a = AnnotationLiteral.of(Named.class, "cat");
+        assertEquals("@javax.inject.Named(value=cat)", a.toString());
+        assertEquals(Named.class, a.annotationType());
+
+        Named cat = Cat.class.getAnnotation(Named.class);
+        assertEquals(a, cat);
+        assertEquals(a.hashCode(), cat.hashCode());
+
+        Named dog = Dog.class.getAnnotation(Named.class);
+        assertNotEquals(a, dog);
+        assertNotEquals(a.hashCode(), dog.hashCode());
+    }
+}


### PR DESCRIPTION
The current release implements annotation literals with `AnnotationParser#annotationForMap`, a private API not available in Java 17. This PR reimplements this functionality using Apache Commons Lang3 as suggested in [this StackOverflow answer](https://stackoverflow.com/a/57373532).