### PR TITLE
Ignore Guice 7.x and later

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      # Starting with 7.x, Guice switches from javax.* to jakarta.* bindings.
+      # See https://github.com/google/guice/wiki/Guice700
+      - dependency-name: "com.google.inject:guice-bom"
+        versions: [">=7.0.0"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
https://github.com/jenkinsci/extensibility-api/pull/7#issuecomment-1548508750 acknowledged that a mistake had been made with a commitment that the same mistake would not be repeated in the future but did nothing to correct the mistake in the present, implicitly leaving it to others to clean up the mess.